### PR TITLE
Resolve #1333 -- Fix "TextInv Train Config Improper Load"

### DIFF
--- a/scripts/diffusers_textual_inversion_2.py
+++ b/scripts/diffusers_textual_inversion_2.py
@@ -215,7 +215,7 @@ def parse_args():
             args = parser.parse_args(namespace=argparse.Namespace(**json.load(f)["args"]))
     elif args.config is not None:
         with open(args.config, 'rt') as f:
-            args = parser.parse_args(namespace=argparse.Namespace(**json.load(f)))
+            args = parser.parse_args(namespace=argparse.Namespace(**json.load(f)["args"]))
 
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
     if env_local_rank != -1 and env_local_rank != args.local_rank:


### PR DESCRIPTION
* Fixed config args being double-loaded and not replacing the defaults.

Closes: #1333

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation